### PR TITLE
Nissix plugin scope-packages on @wix/support-optimizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@wix/wix-express-require-https": "latest",
     "axios": "^0.16.2",
     "babel-runtime": "^6.26.0",
-    "bootstrap-hot-loader": "^3.19.3",
+    "@wix/bootstrap-hot-loader": "^3.19.3",
     "express": "~4.15.0",
     "highcharts": "^7.1.1",
     "i18next": "^11.6.0",
@@ -51,7 +51,7 @@
     "jest-yoshi-preset": "^4.1.0",
     "puppeteer": "^1.1.0",
     "react-testing-library": "^6.0.2",
-    "yoshi": "^4.1.0",
+    "@wix/yoshi": "^4.1.0",
     "yoshi-style-dependencies": "^4.1.0",
     "@wix/wix-bootstrap-testkit": "latest",
     "@wix/wix-config-emitter": "latest"

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,6 @@
 import wixExpressCsrf from '@wix/wix-express-csrf';
 import wixExpressRequireHttps from '@wix/wix-express-require-https';
-import { hot } from 'bootstrap-hot-loader';
+import { hot } from '@wix/bootstrap-hot-loader';
 
 // This function is the main entry for our server. It accepts an express Router
 // (see http://expressjs.com) and attaches routes and middlewares to it.

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-jest');
+module.exports = require('@wix/yoshi/config/wallaby-jest');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.363s



Output Log:
Migrating package "@wix/support-optimizer" in .


## Migration from non scope to @wix/scoped packages
> /tmp/34ed1bb2f61455fedc0e3d58844982f8

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
src/server.js
```

